### PR TITLE
Add version to README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ from pangeo_forge_cmr import files_from_cmr
 
 # Get the GPM IMERG Late Precipitation Daily data
 shortname = 'GPM_3IMERGDL'
+version = '06'
 
 recipe = XarrayZarrRecipe( # We are making Zarr, could be something else too
     files_from_cmr( # Provide a list of files by querying CMR
         shortname,
+        version,
         nitems_per_file=1,
         concat_dim='time',  # Describe how the dataset is chunked
     ),


### PR DESCRIPTION
It seems like in commit [43b77b6](https://github.com/norlandrhagen/pangeo-forge-cmr/commit/43b77b69547959516c9a3528eedde60c0f9f464d), `version` became a mandatory arg. Added in `version` to the README example.